### PR TITLE
test_twitch.py fix mobile emulation with add_experimental_option()

### DIFF
--- a/test/test_twitch.py
+++ b/test/test_twitch.py
@@ -5,7 +5,6 @@ import time
 import pytest
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
-from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
@@ -14,13 +13,16 @@ from selenium.webdriver.support.wait import WebDriverWait
 class TestView():
     @classmethod
     def setup_class(cls):
-        chrome_option = Options()
-        chrome_option.add_argument('--user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/114.0.5735.99 Mobile/15E148 Safari/604.1')
-        cls.driver = webdriver.Chrome(chrome_option)
+        cls.x = 360
+        cls.y = 640
+        mobile_emulation = {
+            "deviceMetrics": {"width": cls.x, "height": cls.y, "pixelRatio": 3.0},
+            "userAgent": "Mozilla/5.0 (Linux; Android 4.2.1; en-us; Nexus 5 Build/JOP40D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"}
+        chrome_options = webdriver.ChromeOptions()
+        chrome_options.add_experimental_option(
+            "mobileEmulation", mobile_emulation)
+        cls.driver = webdriver.Chrome(options=chrome_options)
         cls.driver.implicitly_wait(1)
-        cls.x = 390
-        cls.y = 844
-        cls.driver.set_window_size(cls.x, cls.y)
         cls.wait = WebDriverWait(cls.driver, timeout=2, poll_frequency=1.0)
         logging.debug("Finished setup_class")
 


### PR DESCRIPTION
Previously, I was using the wrong version of webdriver, which caused the test to fail whenever using the add_experimental_option(). 

The function work as it should after installing the right version of the webdriver.

Fix the emulation from the workaround that only uses headers.